### PR TITLE
feat: bump to latest aws provider

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -2,14 +2,13 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    # v5 blocked until https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/280
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 6.0.0"
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = ">= 3.0.0, < 4.0.0"
+      version = ">= 3.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Switch to using github.com as source instead of registry because OpenTofu's registry lags behind Terraform's registry quite a bit. This module still support both Terraform proper and OpenTofu. 

fixes #19